### PR TITLE
Fix resource leak when shutting down

### DIFF
--- a/src/main/java/xyz/rtsvk/alfax/util/Config.java
+++ b/src/main/java/xyz/rtsvk/alfax/util/Config.java
@@ -44,8 +44,7 @@ public class Config extends LinkedHashMap<String, Object> {
 				return cfg;
 			}
 
-			try {
-				Scanner reader = new Scanner(new FileInputStream(file));
+			try (Scanner reader = new Scanner(new FileInputStream(file))) {
 				StringBuilder content = new StringBuilder();
 				while (reader.hasNextLine())
 					content.append(reader.nextLine()).append("\n");

--- a/src/main/resources/default-config.properties
+++ b/src/main/resources/default-config.properties
@@ -2,7 +2,7 @@
 token=your_bot_token_here
 prefix=;
 scheduler-enabled=false
-default-language=en
+default-language=legacy
 force-default-language=false
 command-on-tag=chatgpt
 spammer-enabled=false


### PR DESCRIPTION
Standard input scanner was not being disposed of properly.

Set default language to legacy.